### PR TITLE
Display correct label when autocorrecting

### DIFF
--- a/lib/templatecop/cli.rb
+++ b/lib/templatecop/cli.rb
@@ -69,7 +69,7 @@ module Templatecop
       ).call
 
       offenses = Runner.new(
-        auto_correct: options[:auto_correct],
+        autocorrect: options[:autocorrect],
         debug: options[:debug],
         file_paths: file_paths,
         formatter: formatter,
@@ -89,7 +89,7 @@ module Templatecop
       parser.banner = "Usage: #{@executable_name} [options] [file1, file2, ...]"
       parser.version = VERSION
       parser.on('-a', '--auto-correct', 'Auto-correct offenses.') do
-        options[:auto_correct] = true
+        options[:autocorrect] = true
       end
       parser.on('-c', '--config=', "Specify configuration file. (default: #{@default_configuration_path} or .rubocop.yml)") do |file_path|
         options[:forced_configuration_path] = file_path

--- a/lib/templatecop/ruby_offense_collector.rb
+++ b/lib/templatecop/ruby_offense_collector.rb
@@ -5,19 +5,19 @@ require 'rubocop'
 module Templatecop
   # Collect RuboCop offenses from Ruby code.
   class RubyOffenseCollector
-    # @param [Boolean] auto_correct
+    # @param [Boolean] autocorrect
     # @param [Boolean] debug
     # @param [String] file_path
     # @param [RuboCop::Config] rubocop_config
     # @param [String] source
     def initialize(
-      auto_correct:,
+      autocorrect:,
       file_path:,
       rubocop_config:,
       source:,
       debug: false
     )
-      @auto_correct = auto_correct
+      @autocorrect = autocorrect
       @debug = debug
       @file_path = file_path
       @rubocop_config = rubocop_config
@@ -64,7 +64,8 @@ module Templatecop
       ::RuboCop::Cop::Team.new(
         registry,
         @rubocop_config,
-        auto_correct: @auto_correct,
+        auto_correct: @autocorrect, # DEPRECATED
+        autocorrect: @autocorrect,
         debug: @debug,
         display_cop_names: true,
         extra_details: true,

--- a/lib/templatecop/runner.rb
+++ b/lib/templatecop/runner.rb
@@ -6,21 +6,21 @@ require 'stringio'
 module Templatecop
   # Run investigation and auto-correction.
   class Runner
-    # @param [Boolean] auto_correct
+    # @param [Boolean] autocorrect
     # @param [Boolean] debug
     # @param [Array<String>] file_paths
     # @param [Object] formatter
     # @param [RuboCop::Config] rubocop_config
     # @param [#call] ruby_extractor
     def initialize(
-      auto_correct:,
+      autocorrect:,
       file_paths:,
       formatter:,
       rubocop_config:,
       ruby_extractor:,
       debug: false
     )
-      @auto_correct = auto_correct
+      @autocorrect = autocorrect
       @debug = debug
       @file_paths = file_paths
       @formatter = formatter
@@ -52,20 +52,21 @@ module Templatecop
       ::File.write(file_path, rewritten_source)
     end
 
-    # @param [Boolean] auto_correct
+    # @param [Boolean] autocorrect
+    # @param [Boolean] debug
     # @param [String] file_path
     # @param [String] rubocop_config
     # @param [String] source
     # @return [Array<Templatecop::Offense>]
     def investigate(
-      auto_correct:,
+      autocorrect:,
       debug:,
       file_path:,
       rubocop_config:,
       source:
     )
       TemplateOffenseCollector.new(
-        auto_correct: auto_correct,
+        autocorrect: autocorrect,
         debug: debug,
         file_path: file_path,
         rubocop_config: rubocop_config,
@@ -82,7 +83,7 @@ module Templatecop
           on_file_started(file_path)
           source = ::File.read(file_path)
           offenses = investigate(
-            auto_correct: @auto_correct,
+            autocorrect: @autocorrect,
             debug: @debug,
             file_path: file_path,
             rubocop_config: @rubocop_config,
@@ -91,7 +92,7 @@ module Templatecop
           offenses_per_file |= offenses
           break if offenses.select(&:correctable?).empty?
 
-          next unless @auto_correct
+          next unless @autocorrect
 
           correct(
             file_path: file_path,
@@ -106,7 +107,7 @@ module Templatecop
 
     # @return [Integer]
     def max_trials_count
-      if @auto_correct
+      if @autocorrect
         7 # What a heuristic number.
       else
         1

--- a/lib/templatecop/template_offense_collector.rb
+++ b/lib/templatecop/template_offense_collector.rb
@@ -3,21 +3,21 @@
 module Templatecop
   # Collect RuboCop offenses from Template code.
   class TemplateOffenseCollector
-    # @param [Boolean] auto_correct
+    # @param [Boolean] autocorrect
     # @param [Boolean] debug
     # @param [String] file_path Template file path
     # @param [RuboCop::Config] rubocop_config
     # @param [#call] ruby_extractor
     # @param [String] source Template code
     def initialize(
-      auto_correct:,
+      autocorrect:,
       debug:,
       file_path:,
       rubocop_config:,
       ruby_extractor:,
       source:
     )
-      @auto_correct = auto_correct
+      @autocorrect = autocorrect
       @debug = debug
       @file_path = file_path
       @rubocop_config = rubocop_config
@@ -29,7 +29,7 @@ module Templatecop
     def call
       snippets.flat_map do |snippet|
         RubyOffenseCollector.new(
-          auto_correct: @auto_correct,
+          autocorrect: @autocorrect,
           debug: @debug,
           file_path: @file_path,
           rubocop_config: @rubocop_config,

--- a/spec/templatecop/ruby_offense_collector_spec.rb
+++ b/spec/templatecop/ruby_offense_collector_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Templatecop::RubyOffenseCollector do
   describe '#call' do
     subject do
       described_class.new(
-        auto_correct: false,
+        autocorrect: false,
         file_path: 'dummy.slim',
         rubocop_config: Templatecop::RuboCopConfigGenerator.new(
           default_configuration_path: File.expand_path('../fixtures/default.yml', __dir__),

--- a/spec/templatecop/runner_spec.rb
+++ b/spec/templatecop/runner_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Templatecop::Runner do
   describe '#call' do
     subject do
       described_class.new(
-        auto_correct: false,
+        autocorrect: false,
         file_paths: file_paths,
         formatter: formatter,
         rubocop_config: rubocop_config,


### PR DESCRIPTION
When calling `erbcop -a` I was wondering why it still said `[Correctable]` even though the offenses were corrected.

It turns out that RuboCop's `:auto_correct` option was deprecated in favor of the `:autocorrect` option.

See: https://github.com/rubocop/rubocop/pull/10547