### PR TITLE
Add directory support for PathFinder

### DIFF
--- a/lib/templatecop/path_finder.rb
+++ b/lib/templatecop/path_finder.rb
@@ -28,10 +28,14 @@ module Templatecop
 
     # @return [Array<String>]
     def patterns
-      if @patterns.empty?
-        @default_patterns
-      else
-        @patterns
+      return @default_patterns if @patterns.empty?
+
+      @patterns.map do |pattern|
+        next pattern unless File.directory?(pattern)
+
+        @default_patterns.map do |default|
+          File.join(pattern, default)
+        end.flatten
       end
     end
   end

--- a/spec/templatecop/path_finder_spec.rb
+++ b/spec/templatecop/path_finder_spec.rb
@@ -43,11 +43,13 @@ RSpec.describe Templatecop::PathFinder do
 
     context 'with directory path' do
       let(:patterns) do
-        %w[spec/fixtures]
+        %w[spec]
       end
 
-      it 'excludes directies' do
-        is_expected.to be_empty
+      it 'scans the directory for files matching the default patterns' do
+        is_expected.to eq(
+          [File.expand_path('spec/fixtures/dummy.slim')]
+        )
       end
     end
 


### PR DESCRIPTION
This enables CLI calls like `erbcop app/views` which previously would not scan any files.