### PR TITLE
Respect AllCops Exclude pattern

### DIFF
--- a/lib/templatecop/cli.rb
+++ b/lib/templatecop/cli.rb
@@ -65,6 +65,7 @@ module Templatecop
       ).call
       file_paths = PathFinder.new(
         default_patterns: @default_path_patterns,
+        exclude_patterns: rubocop_config.for_all_cops['Exclude'],
         patterns: @argv
       ).call
 

--- a/spec/templatecop/path_finder_spec.rb
+++ b/spec/templatecop/path_finder_spec.rb
@@ -5,12 +5,17 @@ RSpec.describe Templatecop::PathFinder do
     subject do
       described_class.new(
         default_patterns: default_patterns,
+        exclude_patterns: exclude_patterns,
         patterns: patterns
       ).call
     end
 
     let(:default_patterns) do
       %w[**/*.slim]
+    end
+
+    let(:exclude_patterns) do
+      []
     end
 
     let(:patterns) do
@@ -38,6 +43,20 @@ RSpec.describe Templatecop::PathFinder do
         is_expected.to eq(
           [File.expand_path('spec/fixtures/dummy.slim')]
         )
+      end
+    end
+
+    context 'with glob and exclude pattern' do
+      let(:patterns) do
+        %w[spec/**/*.slim]
+      end
+
+      let(:exclude_patterns) do
+        %w[spec/fixtures/**/*]
+      end
+
+      it 'is empty' do
+        is_expected.to be_empty
       end
     end
 


### PR DESCRIPTION
Prior to this commit, `erbcop` would not respect configuration like

```yaml
AllCops:
  Exclude:
    - 'vendor/**/*'
```

This commit adds support for this configuration key to the `PathFinder`.

We optimize `PathFinder#call` performance by using `Set` which feature constant lookup time and automatic duplicate prevention, and by rewriting

```ruby
Pathname.glob(patterns).select(&:file?).map do |pathname|
```

to a single loop

```ruby
Pathname.glob(patterns) do |pathname|
  next unless pathname.file?
```