### PR TITLE
Add CLI switches for debug mode

### DIFF
--- a/lib/templatecop/cli.rb
+++ b/lib/templatecop/cli.rb
@@ -70,6 +70,7 @@ module Templatecop
 
       offenses = Runner.new(
         auto_correct: options[:auto_correct],
+        debug: options[:debug],
         file_paths: file_paths,
         formatter: formatter,
         rubocop_config: rubocop_config,
@@ -95,6 +96,9 @@ module Templatecop
       end
       parser.on('--[no-]color', 'Force color output on or off.') do |value|
         options[:color] = value
+      end
+      parser.on('-d', '--debug', 'Display debug info.') do |value|
+        options[:debug] = value
       end
       parser.parse!(@argv)
       options

--- a/lib/templatecop/ruby_offense_collector.rb
+++ b/lib/templatecop/ruby_offense_collector.rb
@@ -6,11 +6,19 @@ module Templatecop
   # Collect RuboCop offenses from Ruby code.
   class RubyOffenseCollector
     # @param [Boolean] auto_correct
+    # @param [Boolean] debug
     # @param [String] file_path
     # @param [RuboCop::Config] rubocop_config
     # @param [String] source
-    def initialize(auto_correct:, file_path:, rubocop_config:, source:)
+    def initialize(
+      auto_correct:,
+      debug: false,
+      file_path:,
+      rubocop_config:,
+      source:
+    )
       @auto_correct = auto_correct
+      @debug = debug
       @file_path = file_path
       @rubocop_config = rubocop_config
       @source = source
@@ -41,6 +49,7 @@ module Templatecop
         ::RuboCop::Cop::Registry.new(::RuboCop::Cop::Cop.all),
         @rubocop_config,
         auto_correct: @auto_correct,
+        debug: @debug,
         display_cop_names: true,
         extra_details: true,
         stdin: ''

--- a/lib/templatecop/runner.rb
+++ b/lib/templatecop/runner.rb
@@ -4,21 +4,24 @@ require 'parallel'
 require 'stringio'
 
 module Templatecop
-  # Run investigation and auto-correcttion.
+  # Run investigation and auto-correction.
   class Runner
     # @param [Boolean] auto_correct
+    # @param [Boolean] debug
     # @param [Array<String>] file_paths
     # @param [Object] formatter
     # @param [RuboCop::Config] rubocop_config
     # @param [#call] ruby_extractor
     def initialize(
       auto_correct:,
+      debug: false,
       file_paths:,
       formatter:,
       rubocop_config:,
       ruby_extractor:
     )
       @auto_correct = auto_correct
+      @debug = debug
       @file_paths = file_paths
       @formatter = formatter
       @rubocop_config = rubocop_config
@@ -54,9 +57,16 @@ module Templatecop
     # @param [String] rubocop_config
     # @param [String] source
     # @return [Array<Templatecop::Offense>]
-    def investigate(auto_correct:, file_path:, rubocop_config:, source:)
+    def investigate(
+      auto_correct:,
+      debug:,
+      file_path:,
+      rubocop_config:,
+      source:
+    )
       TemplateOffenseCollector.new(
         auto_correct: auto_correct,
+        debug: debug,
         file_path: file_path,
         rubocop_config: rubocop_config,
         ruby_extractor: @ruby_extractor,
@@ -73,6 +83,7 @@ module Templatecop
           source = ::File.read(file_path)
           offenses = investigate(
             auto_correct: @auto_correct,
+            debug: @debug,
             file_path: file_path,
             rubocop_config: @rubocop_config,
             source: source

--- a/lib/templatecop/template_offense_collector.rb
+++ b/lib/templatecop/template_offense_collector.rb
@@ -4,18 +4,21 @@ module Templatecop
   # Collect RuboCop offenses from Template code.
   class TemplateOffenseCollector
     # @param [Boolean] auto_correct
+    # @param [Boolean] debug
     # @param [String] file_path Template file path
     # @param [RuboCop::Config] rubocop_config
     # @param [#call] ruby_extractor
     # @param [String] source Template code
     def initialize(
       auto_correct:,
+      debug:,
       file_path:,
       rubocop_config:,
       ruby_extractor:,
       source:
     )
       @auto_correct = auto_correct
+      @debug = debug
       @file_path = file_path
       @rubocop_config = rubocop_config
       @ruby_extractor = ruby_extractor
@@ -27,6 +30,7 @@ module Templatecop
       snippets.flat_map do |snippet|
         RubyOffenseCollector.new(
           auto_correct: @auto_correct,
+          debug: @debug,
           file_path: @file_path,
           rubocop_config: @rubocop_config,
           source: snippet[:code]


### PR DESCRIPTION
When a cop raises an exception, RuboCop will swallow it and tell you to use debug mode if you want to see the backtrace.

I needed to add this in order to be able to debug the problems which lead to PR #5.